### PR TITLE
Sublime-like tab rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
                     "pattern": "^.$",
                     "default": "·",
                     "description": "Space indicator symbol."
-                },
+                },                
                 "whiteviz.tabIndicator": {
                     "type": "string",
                     "pattern": "^.$",
-                    "default": "→",
+                    "default": "⸻",
                     "description": "Tab indicator symbol."
                 },
                 "whiteviz.overrideDefault": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
                     "pattern": "^.$",
                     "default": "·",
                     "description": "Space indicator symbol."
-                },                
+                },
                 "whiteviz.tabIndicator": {
                     "type": "string",
                     "pattern": "^.$",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ class WhiteViz {
 
     updateConfigurations(){
         this.clearDecorations();
- 
+
         let configurations = vscode.workspace.getConfiguration("whiteviz");
         this.overrideDefault = configurations.get<boolean>("overrideDefault");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ class WhiteViz {
 
     updateConfigurations(){
         this.clearDecorations();
-
+ 
         let configurations = vscode.workspace.getConfiguration("whiteviz");
         this.overrideDefault = configurations.get<boolean>("overrideDefault");
 
@@ -79,13 +79,20 @@ class WhiteViz {
         this.visualizeOnlyIndentation = configurations.get<boolean>(
             "visualizeOnlyIndentation"
         );
-        let spaceIndicator = configurations.get<string>("spaceIndicator");
-        let tabIndicator = configurations.get<string>("tabIndicator");
 
-        let darkColor = configurations.get<string>(
+        const editorTabSize = parseInt(editorConfigurations.get<string>("tabSize"));
+
+        const spaceIndicator = configurations.get<string>("spaceIndicator");
+        const tabIndicator = editorTabSize % 4 === 0 ?
+            "⸻".repeat(editorTabSize/4)
+            : editorTabSize % 2 === 0
+                ? "⸺"
+                : "—"; //;
+
+        const darkColor = configurations.get<string>(
             "color.dark", configurations.get<string>("color")
         );
-        let lightColor = configurations.get<string>(
+        const lightColor = configurations.get<string>(
             "color.light", configurations.get<string>("color")
         );
 
@@ -94,7 +101,8 @@ class WhiteViz {
         );
         this.tabPattern = configurations.get<string>("tabPattern");
 
-        let margin = "0ch -1ch 0ch 0ch";
+        const spaceMargin = "0 -1ch 0 0";
+        const tabMargin = `0 -${editorTabSize}ch 0 0`;
 
         this.whitespaceDecoration = (
             vscode.window.createTextEditorDecorationType(
@@ -102,14 +110,14 @@ class WhiteViz {
                     light: {
                         before: {
                             contentText: spaceIndicator,
-                            margin: margin,
+                            margin: spaceMargin,
                             color: lightColor
                         }
                     },
                     dark: {
                         before: {
                             contentText: spaceIndicator,
-                            margin: margin,
+                            margin: spaceMargin,
                             color: darkColor
                         }
                     }
@@ -122,14 +130,14 @@ class WhiteViz {
                     light: {
                         before: {
                             contentText: tabIndicator,
-                            margin: margin,
+                            margin: tabMargin,
                             color: lightColor
                         }
                     },
                     dark: {
                         before: {
                             contentText: tabIndicator,
-                            margin: margin,
+                            margin: tabMargin,
                             color: darkColor
                         }
                     }


### PR DESCRIPTION
I got inspired by https://github.com/Microsoft/vscode/issues/25021

Before:
![](https://cloud.githubusercontent.com/assets/11352152/25310340/0e8ae58a-27d2-11e7-84b7-914cf85425bd.png)

After:
![new](https://cloud.githubusercontent.com/assets/11352152/25310952/35f40da8-27e2-11e7-97e4-2bbc9837c1d7.png)

Especially helpful to check if indendation is consistent in css:
![styl](https://cloud.githubusercontent.com/assets/11352152/25310958/674a8404-27e2-11e7-813b-65275a66cf0a.png)

The screenshots above use `editor.tabSize:4`, but the implementation is flexible for 2-wide and 8-wide tabs as well.

The estimated tab glyph width can sometimes be off by 1-2px depending on the font, but that can be improved in the future with some additional effort. 
